### PR TITLE
Task 1393- Search Job Types

### DIFF
--- a/src/main/java/model/job/PiazzaJobType.java
+++ b/src/main/java/model/job/PiazzaJobType.java
@@ -26,6 +26,8 @@ import model.job.type.IngestJob;
 import model.job.type.ListServicesJob;
 import model.job.type.RegisterServiceJob;
 import model.job.type.RepeatJob;
+import model.job.type.SearchMetadataIngestJob;
+import model.job.type.SearchQueryJob;
 import model.job.type.SearchServiceJob;
 import model.job.type.UpdateServiceJob;
 
@@ -51,6 +53,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 		@Type(value = DeleteServiceJob.class, name = "delete-service"),
 		@Type(value = ExecuteServiceJob.class, name = "execute-service"), @Type(value = GetJob.class, name = "get"),
 		@Type(value = IngestJob.class, name = "ingest"),
+		@Type(value = SearchMetadataIngestJob.class, name = "search-metadata-ingest"),
+		@Type(value = SearchQueryJob.class, name = "search-query"),
 		@Type(value = DescribeServiceMetadataJob.class, name = "read-service"),
 		@Type(value = RegisterServiceJob.class, name = "register-service"),
 		@Type(value = UpdateServiceJob.class, name = "update-service"),

--- a/src/main/java/model/job/type/SearchMetadataIngestJob.java
+++ b/src/main/java/model/job/type/SearchMetadataIngestJob.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016, RadiantBlue Technologies, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package model.job.type;
+
+import model.data.DataResource;
+import model.job.PiazzaJobType;
+
+/**
+ * Represents the JSON Model for ingesting metadata into Piazza for subsequent query,
+ * e.g. used in conjunction/within the flow of an InjestJob
+ * The contents of this payload includes DataResource serving as complete metadata
+ * record to locate Piazza data access key(s) from Search service.
+ * 
+ * @author Christopher Smith
+ * 
+ */
+public class SearchMetadataIngestJob implements PiazzaJobType {
+	public final String type = "search-metadata-ingest";
+	public DataResource data;
+
+	public SearchMetadataIngestJob() {
+
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public DataResource getData() {
+		return data;
+	}
+
+}

--- a/src/main/java/model/job/type/SearchQueryJob.java
+++ b/src/main/java/model/job/type/SearchQueryJob.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2016, RadiantBlue Technologies, Inc.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ **/
+package model.job.type;
+
+import model.data.DataResource;
+import model.job.PiazzaJobType;
+
+/**
+ * Represents the JSON Model for ingesting metadata into Piazza for subsequent query,
+ * e.g. used in conjunction/within the flow of an InjestJob
+ * The contents of this payload includes DataResource serving as complete metadata
+ * record to locate Piazza data access key(s) from Search service.
+ * 
+ * @author Christopher Smith
+ * 
+ */
+public class SearchQueryJob implements PiazzaJobType {
+	public final String type = "search-query";
+	public DataResource data;
+
+	public SearchQueryJob() {
+
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public DataResource getData() {
+		return data;
+	}
+
+}

--- a/src/main/java/model/job/type/SearchQueryJob.java
+++ b/src/main/java/model/job/type/SearchQueryJob.java
@@ -19,17 +19,18 @@ import model.data.DataResource;
 import model.job.PiazzaJobType;
 
 /**
- * Represents the JSON Model for ingesting metadata into Piazza for subsequent query,
- * e.g. used in conjunction/within the flow of an InjestJob
- * The contents of this payload includes DataResource serving as complete metadata
- * record to locate Piazza data access key(s) from Search service.
+ * Represents the JSON Model passing Elasticsearch Query (DSL language)
+ * into Piazza for search query,
  * 
  * @author Christopher Smith
  * 
  */
 public class SearchQueryJob implements PiazzaJobType {
 	public final String type = "search-query";
-	public DataResource data;
+	/**
+	 * Hunk-o-memory for serialization of input DSL
+	 */
+	public Object data;
 
 	public SearchQueryJob() {
 
@@ -39,7 +40,7 @@ public class SearchQueryJob implements PiazzaJobType {
 		return type;
 	}
 
-	public DataResource getData() {
+	public Object getData() {
 		return data;
 	}
 


### PR DESCRIPTION
Addition of classes for Search (metadata in ES) jobs.  SearchQueryJob data expected is well-formed Elasticsearch DSL query as Java Object.