### PR TITLE
Updated to add missing output datatype

### DIFF
--- a/src/main/java/model/service/metadata/ExecuteServiceData.java
+++ b/src/main/java/model/service/metadata/ExecuteServiceData.java
@@ -40,8 +40,20 @@ public class ExecuteServiceData {
 	public void setDataInputs(Map<String, DataType> dataInputs) {
 		this.dataInputs = dataInputs;
 	}
+	
+	public DataType getDataOutput() {
+		return dataOutput;
+	}
+	public void setDataOutput(DataType dataOutput) {
+		this.dataOutput = dataOutput;
+	}
+	
 	@JsonProperty("dataInputs")
 	public Map<String, DataType> dataInputs;	
+	
+	@JsonProperty("dataOutput")
+	public DataType dataOutput;
+
 	
 	
 }


### PR DESCRIPTION
All, this output datatype was added because if the user registers a service with multiple output types, they need to specify which one they are expecting as output so the core can handle accordingly..